### PR TITLE
Making Processing-Templates fit for Git

### DIFF
--- a/android-library-template/.gitignore
+++ b/android-library-template/.gitignore
@@ -1,0 +1,2 @@
+/distribution
+local.properties

--- a/android-library-template/resources/ChangeLog.txt
+++ b/android-library-template/resources/ChangeLog.txt
@@ -1,3 +1,10 @@
+2013-02-04	Martin Schneider
+      * version 0.4.8
+      * sepearated local system properties from project specific build properties
+      * local.properties.tmpl: template for configuring local paths of the build system
+      * .gitignore: hiding local.properties from revision control
+      * build.xml: updated the build-script to use both local.properties and build.properties
+
 2012-02-16  Elie Zananiri
       * version 0.4.7
       * fixed up formatting to match new tool template

--- a/android-library-template/resources/build.properties
+++ b/android-library-template/resources/build.properties
@@ -1,80 +1,11 @@
-# Create libraries for the Processing open source programming language and 
+# Create Android libraries for the Processing open source programming language and 
 # environment (http://www.processing.org)
 #
-# Customize the build properties to make the ant-build-process work for your 
-# environment. How? Please read the comments below.
-#
-# The default properties are set for OSX, for Windows-settings please refer to 
-# comments made under (1) and (2).
+# Customize the build properties for your project here.
+# How? Please read the comments below.
 
 
-
-# (1) 
-# Where is your Processing sketchbook located?
-# If you are not sure, check the sketchbook location in your Processing 
-# application preferences.
-# 
-# ${user.home} points the compiler to your home directory.
-# For windows the default path to your sketchbook would be
-# ${user.home}/My Documents/Processing (make adjustments below).
-
-sketchbook.location=${user.home}/Documents/Processing
-
-
-
-# (2) 
-# Where are the core library files located that are required for compiling
-# your library such as e.g. core.jar or android-core.zip?
-# By default the local classpath location points to folder libs inside Eclipse's
-# workspace (by default found in your home directory).
-# For Windows the default path would be ${user.home}/workspace/libs (make 
-# adjustments below).
-
-#classpath.local.location=${user.home}/Documents/workspace/libs
-
-
-# For OSX users. 
-# The following path will direct you into Processing's application source code 
-# folder in case you put Processing inside your Applications folder. 
-# Uncommenting the line below will overwrite the classpath.local.location from 
-# above.
-
-classpath.local.location=/Applications/Processing.app/Contents/Resources/Java/modes/android/
-
-
-# Add the Processing Android Core file (android-core.zip) that is required for
-# compiling your project to the local and project classpath. This file must be
-# inside your classpath.local.location folder.
-
-classpath.local.include=android-core.zip
-
-
-
-# Android Platform
-# The following paths point to the location of the version of android.jar
-# required to build your project. As of Processing 2.0a6, API Level 10 is the
-# minimum version, but your library may require a higher level if it includes
-# newer features like NFC or Wi-Fi direct.
-
-# android_platform.location is dependent on where you installed the Android SDK
-
-android_platform.location=${user.home}/android-sdk-macosx/platforms/android-10/
-
-# android_platform.include will probably always be android.jar
-
-android_platform.include=android.jar
-
-
-# Add processing's libraries folder to the classpath.
-# If you don't need to include any installed libraries in the classpath, change
-# change this to a path that does not exist (but note that it will be created
-# during the build).
-
-classpath.libraries.location=${sketchbook.location}/libraries
-
-
-
-# (3)
+# (1)
 # Set the java version that should be used to compile your library.
 
 java.target.version=1.6
@@ -82,16 +13,15 @@ java.target.version=1.6
 
 # Set the description of the Ant build.xml file.
 
-#jra ant.description=ProcessingLibs Ant build file.
 ant.description=ProcessingLibs Ant build file.
 
 
 
-# (4)
+# (2)
 # Project details.
 # Give your library a name.
 
-project.name=YourLibrary
+project.name=YourAndroidLibrary
 
 
 # Use 'normal' or 'fast' as value for project.compile.
@@ -106,7 +36,7 @@ project.compile=normal
 
 
 
-# (5)
+# (3)
 # The following items are properties that will be used to make changes to the 
 # web document templates. Values of properties will be inserted into the 
 # documents automatically.
@@ -173,7 +103,7 @@ library.version=1
 library.prettyVersion=0.1.1
 
 
-library.copyright=(C) 2012
+library.copyright=(c) 2013
 library.dependencies=?
 library.keywords=?
 

--- a/android-library-template/resources/build.xml
+++ b/android-library-template/resources/build.xml
@@ -16,6 +16,7 @@
     
 	
 
+	<property file="./resources/local.properties" />
 	<property file="./resources/build.properties" />
 	
 	<description>

--- a/android-library-template/resources/local.properties.tmpl
+++ b/android-library-template/resources/local.properties.tmpl
@@ -1,0 +1,77 @@
+# Create Android libraries for the Processing open source programming language and 
+# environment (http://www.processing.org)
+#
+# Create a copy of this file named "local.properties" and customize the properties to 
+# make the ant-build-process work for your environment.
+# How? Please read the comments below.
+#
+# The default properties are set for OSX, for Windows-settings please refer to 
+# comments made under (1) and (2).
+
+
+
+# (1) 
+# Where is your Processing sketchbook located?
+# If you are not sure, check the sketchbook location in your Processing 
+# application preferences.
+# 
+# ${user.home} points the compiler to your home directory.
+# For windows the default path to your sketchbook would be
+# ${user.home}/My Documents/Processing (make adjustments below).
+
+sketchbook.location=${user.home}/Documents/Processing
+
+
+
+# (2) 
+# Where are the core library files located that are required for compiling
+# your library such as e.g. core.jar or android-core.zip?
+# By default the local classpath location points to folder libs inside Eclipse's
+# workspace (by default found in your home directory).
+# For Windows the default path would be ${user.home}/workspace/libs (make 
+# adjustments below).
+
+#classpath.local.location=${user.home}/Documents/workspace/libs
+
+
+# For OSX users. 
+# The following path will direct you into Processing's application source code 
+# folder in case you put Processing inside your Applications folder. 
+# Uncommenting the line below will overwrite the classpath.local.location from 
+# above.
+
+classpath.local.location=/Applications/Processing.app/Contents/Resources/Java/modes/android/
+
+
+# Add the Processing Android Core file (android-core.zip) that is required for
+# compiling your project to the local and project classpath. This file must be
+# inside your classpath.local.location folder.
+
+classpath.local.include=android-core.zip
+
+
+
+# Android Platform
+# The following paths point to the location of the version of android.jar
+# required to build your project. As of Processing 2.0a6, API Level 10 is the
+# minimum version, but your library may require a higher level if it includes
+# newer features like NFC or Wi-Fi direct.
+
+# android_platform.location is dependent on where you installed the Android SDK
+
+android_platform.location=${user.home}/android-sdk-macosx/platforms/android-10/
+
+# android_platform.include will probably always be android.jar
+
+android_platform.include=android.jar
+
+
+# Add processing's libraries folder to the classpath.
+# If you don't need to include any installed libraries in the classpath, change
+# this to a path that does not exist (but note that it will be created during
+# the build).
+
+classpath.libraries.location=${sketchbook.location}/libraries
+
+
+

--- a/library-template/.gitignore
+++ b/library-template/.gitignore
@@ -1,0 +1,2 @@
+/distribution
+local.properties

--- a/library-template/resources/ChangeLog.txt
+++ b/library-template/resources/ChangeLog.txt
@@ -1,3 +1,10 @@
+2013-02-04	Martin Schneider
+      * version 0.4.9
+      * sepearated local system properties from project specific build properties
+      * local.properties.tmpl: template for configuring local paths of the build system
+      * .gitignore: hiding local.properties from revision control
+      * build.xml: updated the build-script to use both local.properties and build.properties
+
 2012-10-05  Elie Zananiri
       * version 0.4.8
       * updated default classpath on OS X

--- a/library-template/resources/build.properties
+++ b/library-template/resources/build.properties
@@ -1,62 +1,11 @@
 # Create libraries for the Processing open source programming language and 
 # environment (http://www.processing.org)
 #
-# Customize the build properties to make the ant-build-process work for your 
-# environment. How? Please read the comments below.
-#
-# The default properties are set for OSX, for Windows-settings please refer to 
-# comments made under (1) and (2).
+# Customize the build properties for your project here.
+# How? Please read the comments below.
 
 
-
-# (1) 
-# Where is your Processing sketchbook located? 
-# If you are not sure, check the sketchbook location in your Processing 
-# application preferences.
-# ${user.home} points the compiler to your home directory.
-# For windows the default path to your sketchbook would be
-# ${user.home}/My Documents/Processing (make adjustments below).
-
-sketchbook.location=${user.home}/Documents/Processing
-
-
-
-# (2) 
-# Where are the jar files located that are required for compiling your library 
-# such as e.g. core.jar?
-# By default the local classpath location points to folder libs inside Eclipse's
-# workspace (by default found in your home directory).
-# For Windows the default path would be ${user.home}/workspace/libs (make 
-# adjustments below).
-
-#classpath.local.location=${user.home}/Documents/workspace/libs
-
-
-# For OSX users. 
-# The following path will direct you into Processing's application source code 
-# folder in case you put Processing inside your Applications folder. 
-# Uncommenting the line below will overwrite the classpath.local.location from 
-# above.
-
-classpath.local.location=/Applications/Processing.app/Contents/Resources/Java/core/library/
-
-
-# Add all jar files that are required for compiling your project to the local 
-# and project classpath, use a comma as delimiter. These jar files must be 
-# inside your classpath.local.location folder.
-
-classpath.local.include=core.jar
-
-
-# Add processing's libraries folder to the classpath.
-# If you don't need to include the libraries folder to your classpath, comment 
-# out the following line.
-
-classpath.libraries.location=${sketchbook.location}/libraries
-
-
-
-# (3)
+# (1)
 # Set the java version that should be used to compile your library.
 
 java.target.version=1.6
@@ -68,7 +17,7 @@ ant.description=ProcessingLibs Ant build file.
 
 
 
-# (4)
+# (2)
 # Project details.
 # Give your library a name.
 
@@ -87,7 +36,7 @@ project.compile=normal
 
 
 
-# (5)
+# (3)
 # The following items are properties that will be used to make changes to the 
 # web document templates. Values of properties will be inserted into the 
 # documents automatically.
@@ -154,7 +103,7 @@ library.version=1
 library.prettyVersion=0.1.1
 
 
-library.copyright=(C) 2012
+library.copyright=(c) 2013
 library.dependencies=?
 library.keywords=?
 

--- a/library-template/resources/build.xml
+++ b/library-template/resources/build.xml
@@ -12,6 +12,7 @@
     
 	
 
+	<property file="./resources/local.properties" />
 	<property file="./resources/build.properties" />
 	
 	<description>

--- a/library-template/resources/local.properties.tmpl
+++ b/library-template/resources/local.properties.tmpl
@@ -1,0 +1,63 @@
+# Create libraries for the Processing open source programming language and 
+# environment (http://www.processing.org)
+#
+# Create a copy of this file named "local.properties" and customize the properties to 
+# make the ant-build-process work for your environment.
+# How? Please read the comments below.
+#
+# The default properties are set for OSX, for Windows-settings please refer to 
+# comments made under (1) and (2).
+
+
+# (1) 
+# Where is your Processing sketchbook located? 
+# If you are not sure, check the sketchbook location in your Processing 
+# application preferences.
+# ${user.home} points the compiler to your home directory.
+# For windows the default path to your sketchbook would be
+# ${user.home}/My Documents/Processing (make adjustments below).
+
+sketchbook.location=${user.home}/Documents/Processing
+
+
+
+# (2) 
+# Where are the jar files located that are required for compiling your tool such
+# as e.g. core.jar?
+# By default the local classpath location points to folder libs inside Eclipse's
+# workspace (by default found in your home directory).
+# For Windows the default path would be ${user.home}/workspace/libs (make 
+# adjustments below).
+
+#classpath.local.location=${user.home}/Documents/workspace/libs
+
+
+# For OSX users. 
+# The following path will direct you into Processing's application source code 
+# folder in case you put Processing inside your Applications folder. 
+# Uncommenting the line below will overwrite the classpath.local.location from 
+# above.
+
+classpath.local.location=/Applications/Processing.app/Contents/Resources/Java/core/library/
+
+
+# Add all jar files that are required for compiling your project to the local 
+# and project classpath, use a comma as delimiter. These jar files must be 
+# inside your classpath.local.location folder.
+#
+# For creating a tool, both pde.jar and core.jar are required. (pde.jar should 
+# then be located inside folder classpath.local.location). 
+# The best practice would be to place both, core.jar and pde.jar into your local
+# classpath location.
+
+classpath.local.include=core.jar,pde.jar
+
+
+# Add processing's libraries folder to the classpath.
+# If you don't need to include the libraries folder to your classpath, comment 
+# out the following line.
+
+classpath.libraries.location=${sketchbook.location}/libraries
+
+
+

--- a/tool-template/.gitignore
+++ b/tool-template/.gitignore
@@ -1,0 +1,2 @@
+/distribution
+local.properties

--- a/tool-template/resources/ChangeLog.txt
+++ b/tool-template/resources/ChangeLog.txt
@@ -1,3 +1,10 @@
+2013-02-04	Martin Schneider
+      * version 0.2.3
+      * sepearated local system properties from project specific build properties
+      * local.properties.tmpl: template for configuring local paths of the build system
+      * .gitignore: hiding local.properties from revision control
+      * build.xml: updated the build-script to use both local.properties and build.properties
+
 2012-10-05  Elie Zananiri
       * version 0.2.2
       * updated default classpath on OS X

--- a/tool-template/resources/build.properties
+++ b/tool-template/resources/build.properties
@@ -1,67 +1,11 @@
 # Create tools for the Processing open source programming language and 
 # environment (http://www.processing.org)
-#
-# Customize the build properties to make the ant-build-process work for your 
-# environment. How? Please read the comments below.
-#
-# The default properties are set for OSX, for Windows-settings please refer to 
-# comments made under (1) and (2).
+
+# Customize the build properties for your project here.
+# How? Please read the comments below.
 
 
-
-# (1) 
-# Where is your Processing sketchbook located? 
-# If you are not sure, check the sketchbook location in your Processing 
-# application preferences.
-# ${user.home} points the compiler to your home directory.
-# For windows the default path to your sketchbook would be
-# ${user.home}/My Documents/Processing (make adjustments below).
-
-sketchbook.location=${user.home}/Documents/Processing
-
-
-
-# (2) 
-# Where are the jar files located that are required for compiling your tool such
-# as e.g. core.jar?
-# By default the local classpath location points to folder libs inside Eclipse's
-# workspace (by default found in your home directory).
-# For Windows the default path would be ${user.home}/workspace/libs (make 
-# adjustments below).
-
-#classpath.local.location=${user.home}/Documents/workspace/libs
-
-
-# For OSX users. 
-# The following path will direct you into Processing's application source code 
-# folder in case you put Processing inside your Applications folder. 
-# Uncommenting the line below will overwrite the classpath.local.location from 
-# above.
-
-classpath.local.location=/Applications/Processing.app/Contents/Resources/Java/core/library/
-
-
-# Add all jar files that are required for compiling your project to the local 
-# and project classpath, use a comma as delimiter. These jar files must be 
-# inside your classpath.local.location folder.
-#
-# For creating a tool, both pde.jar and core.jar are required. (pde.jar should 
-# then be located inside folder classpath.local.location). 
-# The best practice would be to place both, core.jar and pde.jar into your local
-# classpath location.
-
-classpath.local.include=core.jar,pde.jar
-
-
-# Add processing's libraries folder to the classpath.
-# If you don't need to include the libraries folder to your classpath, comment 
-# out the following line.
-
-classpath.libraries.location=${sketchbook.location}/libraries
-
-
-
-# (3)
+# (1)
 # Set the java version that should be used to compile your tool.
 
 java.target.version=1.6
@@ -73,7 +17,7 @@ ant.description=ProcessingTools Ant build file.
 
 
 
-# (4)
+# (2)
 # Project details.
 # Give your tool a name.
 # When creating a tool, the name of the main class which implements Tool must be
@@ -94,7 +38,7 @@ project.compile=normal
 
 
 
-# (5)
+# (3)
 # The following items are properties that will be used to make changes to the 
 # web document templates. Values of properties will be inserted into the 
 # documents automatically.
@@ -160,7 +104,7 @@ tool.version=1
 tool.prettyVersion=0.1.1
 
 
-tool.copyright=(C) 2012
+tool.copyright=(c) 2013
 tool.dependencies=?
 tool.keywords=?
 

--- a/tool-template/resources/build.xml
+++ b/tool-template/resources/build.xml
@@ -12,6 +12,7 @@
     
 	
 
+	<property file="./resources/local.properties" />
 	<property file="./resources/build.properties" />
 	
 	<description>

--- a/tool-template/resources/local.properties.tmpl
+++ b/tool-template/resources/local.properties.tmpl
@@ -1,0 +1,63 @@
+# Create tools for the Processing open source programming language and 
+# environment (http://www.processing.org)
+#
+# Create a copy of this file named "local.properties" and customize the properties to 
+# make the ant-build-process work for your environment.
+# How? Please read the comments below.
+#
+# The default properties are set for OSX, for Windows-settings please refer to 
+# comments made under (1) and (2).
+
+
+# (1) 
+# Where is your Processing sketchbook located? 
+# If you are not sure, check the sketchbook location in your Processing 
+# application preferences.
+# ${user.home} points the compiler to your home directory.
+# For windows the default path to your sketchbook would be
+# ${user.home}/My Documents/Processing (make adjustments below).
+
+sketchbook.location=${user.home}/Documents/Processing
+
+
+
+# (2) 
+# Where are the jar files located that are required for compiling your tool such
+# as e.g. core.jar?
+# By default the local classpath location points to folder libs inside Eclipse's
+# workspace (by default found in your home directory).
+# For Windows the default path would be ${user.home}/workspace/libs (make 
+# adjustments below).
+
+#classpath.local.location=${user.home}/Documents/workspace/libs
+
+
+# For OSX users. 
+# The following path will direct you into Processing's application source code 
+# folder in case you put Processing inside your Applications folder. 
+# Uncommenting the line below will overwrite the classpath.local.location from 
+# above.
+
+classpath.local.location=/Applications/Processing.app/Contents/Resources/Java/core/library/
+
+
+# Add all jar files that are required for compiling your project to the local 
+# and project classpath, use a comma as delimiter. These jar files must be 
+# inside your classpath.local.location folder.
+#
+# For creating a tool, both pde.jar and core.jar are required. (pde.jar should 
+# then be located inside folder classpath.local.location). 
+# The best practice would be to place both, core.jar and pde.jar into your local
+# classpath location.
+
+classpath.local.include=core.jar,pde.jar
+
+
+# Add processing's libraries folder to the classpath.
+# If you don't need to include the libraries folder to your classpath, comment 
+# out the following line.
+
+classpath.libraries.location=${sketchbook.location}/libraries
+
+
+


### PR DESCRIPTION
**Problem**

When several people work on a Processing library or tool via git, they usually have different classpaths, sketchbook locations etc. These things are configured in a file that is currently under version control (which is a bad thing).

**Solution**
- Create custom config files named `local.properties` that are excluded from version control.
- Provide template files: `local.properties.tmpl` that the developers need to copy and customize to their needs.
- modify the build process to use both `local.properties` and `build.properties`
