### PR TITLE
Extension of .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,10 @@
 distribution
+.DS_Store
+*.swp
+*.iml
+*.ipr
+*.iws
+.classpath
+.project
+.settings/
+.springBeans/

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ distribution
 .project
 .settings/
 .springBeans/
+.metadata/

--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,11 @@
 distribution
-.DS_Store
+*.DS_Store
 *.swp
 *.iml
 *.ipr
 *.iws
-.classpath
-.project
-.settings/
-.springBeans/
-.metadata/
+*.classpath
+*.project
+*.settings/
+*.springBeans/
+*.metadata/


### PR DESCRIPTION
Untrack the following files for independent version control:

```
*.DS_Store
*.swp
*.iml
*.ipr
*.iws
*.classpath
*.project
*.settings/
*.springBeans/
*.metadata/
```

If you import the project into Eclipse, you will get a conflict because of the existing .classpath and .project file:

``` xml
<?xml version="1.0" encoding="UTF-8"?>
<classpath>
    <classpathentry kind="src" output="bin" path="src"/>
    <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
    <classpathentry combineaccessrules="false" kind="src" path="/processing-core"/>
    <classpathentry kind="output" path="resources/code"/>
</classpath>
```

And it's better, if you checkout the basic code without .project meta data.

``` xml
<?xml version="1.0" encoding="UTF-8"?>
<projectDescription>
    <name>processing-library-template</name>
    <comment></comment>
    <projects>
    </projects>
    <buildSpec>
        <buildCommand>
            <name>org.eclipse.jdt.core.javabuilder</name>
            <arguments>
            </arguments>
        </buildCommand>
    </buildSpec>
    <natures>
        <nature>org.eclipse.jdt.core.javanature</nature>
    </natures>
</projectDescription>
```

Then check the following link:

```
http://stackoverflow.com/questions/1139762/gitignore-file-not-ignoring
```
