### PR TITLE
Add separate environment for developing and testing.

### DIFF
--- a/library-template/resources/build.xml
+++ b/library-template/resources/build.xml
@@ -143,6 +143,7 @@ ${line}
 				<path refid="classpath"/>
 			</classpath>
 			<compilerarg value="-Xlint"/>
+			<exclude name="development/**" />
 		</javac>
 		<copy todir="${project.bin.data}">
 			<fileset dir="${project.data}" excludes="README" />
@@ -225,6 +226,7 @@ ${line}
  			<fileset dir="${project.tmp}/${project.name}/src" defaultexcludes="yes">
 			<!-- add packages to be added to reference. -->
 				<include name="**/*"/>
+ 				<exclude name="development/**" />
 			</fileset>
 	 	</javadoc>
 	</target>

--- a/library-template/src/development/Sketch.java
+++ b/library-template/src/development/Sketch.java
@@ -1,0 +1,35 @@
+package development;
+
+import processing.core.PApplet;
+import template.library.*;
+
+/**
+ * This is a class in a separate package 'development' for developing and testing.
+ * Don't rename the package! While the build-process it will be automatically exclude.
+ */
+
+public class Sketch extends PApplet {
+
+	HelloLibrary hello;
+
+	public void setup() {
+		size(500, 500);
+		background(0);
+
+		hello = new HelloLibrary(this);
+	}
+
+	public void draw() {
+		background(0);
+
+		println(hello.sayHello());
+	}
+
+	public static void main(String args[]) {
+		PApplet.main(new String[] { "development.Sketch" });
+
+		// Or run the sketch in present-mode:
+		// PApplet.main(new String[] { "--present", "development.Sketch" });
+	}
+
+}


### PR DESCRIPTION
Hello,

here is an extension to improve the developing-process.

There is the class 'Sketch' in a separate package 'development' for developing and testing, which the developer can use to develop faster. While the build-process the package will be automatically exclude. So the developer can test immediately, because it's not necessary to start the build-process. That's my way to develop p5 libraries, and I want to share it. If you think, that it's useful, you can add it.

Darius
